### PR TITLE
remove unused substrate in chemotactic_sensitivity

### DIFF
--- a/user_projects/pdac_therapy/config/PhysiCell_settings.xml
+++ b/user_projects/pdac_therapy/config/PhysiCell_settings.xml
@@ -229,7 +229,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -397,7 +396,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -566,7 +564,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -735,7 +732,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -904,7 +900,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -1075,7 +1070,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -1239,7 +1233,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -1407,7 +1400,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -1575,7 +1567,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>

--- a/user_projects/tam_egf/config/PhysiCell_settings_go.xml
+++ b/user_projects/tam_egf/config/PhysiCell_settings_go.xml
@@ -263,7 +263,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -445,7 +444,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -627,7 +625,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -809,7 +806,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -991,7 +987,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>

--- a/user_projects/tam_egf/config/PhysiCell_settings_go_and_grow.xml
+++ b/user_projects/tam_egf/config/PhysiCell_settings_go_and_grow.xml
@@ -263,7 +263,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -445,7 +444,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -627,7 +625,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -809,7 +806,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -991,7 +987,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>

--- a/user_projects/tam_egf/config/PhysiCell_settings_grow.xml
+++ b/user_projects/tam_egf/config/PhysiCell_settings_grow.xml
@@ -261,7 +261,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -440,7 +439,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -619,7 +617,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -798,7 +795,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -977,7 +973,6 @@
                                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="IL-4">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="EGF">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>

--- a/user_projects/tumor_immune_base/config/PhysiCell_settings.xml
+++ b/user_projects/tumor_immune_base/config/PhysiCell_settings.xml
@@ -232,7 +232,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -395,7 +394,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>
@@ -558,7 +556,6 @@
                                 <chemotactic_sensitivity substrate="debris">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="pro-inflammatory factor">0.0</chemotactic_sensitivity>
                                 <chemotactic_sensitivity substrate="anti-inflammatory factor">0.0</chemotactic_sensitivity>
-                                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
                             </chemotactic_sensitivities>
                         </advanced_chemotaxis>
                     </options>

--- a/user_projects/tumor_immune_extended/config/PhysiCell_settings.xml
+++ b/user_projects/tumor_immune_extended/config/PhysiCell_settings.xml
@@ -246,7 +246,6 @@
                 <chemotactic_sensitivity substrate="oxygen">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IFN-gamma">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
-                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
               </chemotactic_sensitivities>
             </advanced_chemotaxis>
           </options>
@@ -438,7 +437,6 @@
                 <chemotactic_sensitivity substrate="oxygen">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IFN-gamma">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
-                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
               </chemotactic_sensitivities>
             </advanced_chemotaxis>
           </options>
@@ -630,7 +628,6 @@
                 <chemotactic_sensitivity substrate="oxygen">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IFN-gamma">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
-                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
               </chemotactic_sensitivities>
             </advanced_chemotaxis>
           </options>
@@ -822,7 +819,6 @@
                 <chemotactic_sensitivity substrate="oxygen">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IFN-gamma">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
-                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
               </chemotactic_sensitivities>
             </advanced_chemotaxis>
           </options>
@@ -1015,7 +1011,6 @@
                 <chemotactic_sensitivity substrate="oxygen">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IFN-gamma">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
-                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
               </chemotactic_sensitivities>
             </advanced_chemotaxis>
           </options>
@@ -1207,7 +1202,6 @@
                 <chemotactic_sensitivity substrate="oxygen">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IFN-gamma">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
-                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
               </chemotactic_sensitivities>
             </advanced_chemotaxis>
           </options>
@@ -1397,7 +1391,6 @@
                 <chemotactic_sensitivity substrate="oxygen">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IFN-gamma">0.0</chemotactic_sensitivity>
                 <chemotactic_sensitivity substrate="IL-10">0.0</chemotactic_sensitivity>
-                <chemotactic_sensitivity substrate="substrate">0.0</chemotactic_sensitivity>
               </chemotactic_sensitivities>
             </advanced_chemotaxis>
           </options>


### PR DESCRIPTION
The "substrate" substrate was listed in the `<chemotactic_sensitivities>` but was never defined, leading to an unsettling Warning about being `Invalid` and `Ignoring` at runtime.